### PR TITLE
Collision detection expose detailed distance information from fcl

### DIFF
--- a/collision_detection/include/moveit/collision_detection/collision_common.h
+++ b/collision_detection/include/moveit/collision_detection/collision_common.h
@@ -45,6 +45,7 @@
 #include <set>
 #include <Eigen/Core>
 #include <console_bridge/console.h>
+#include <fcl/distance.h>
 
 namespace collision_detection
 {
@@ -130,6 +131,25 @@ namespace collision_detection
     }
   };
 
+  /** \brief Representation of a detailed distance */
+  struct DetailedDistance
+  {
+    DetailedDistance(std::string nearest_object, fcl::DistanceResult dist_result)
+    {
+      this->distance = dist_result.min_distance;
+      this->nearest_object = nearest_object;
+      this->nearest_points.first = Eigen::Vector3d(dist_result.nearest_points[0].data.vs);
+      this->nearest_points.second = Eigen::Vector3d(dist_result.nearest_points[1].data.vs);
+    }
+    DetailedDistance(){}
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+    double distance; /**< Distance between objects */
+    std::string nearest_object; /**< Nearest object link name */
+    std::pair<Eigen::Vector3d, Eigen::Vector3d> nearest_points; /**< Point on each object */
+  };
+
   /** \brief Representation of a collision checking result */
   struct CollisionResult
   {
@@ -139,6 +159,7 @@ namespace collision_detection
     {
     }
     typedef std::map<std::pair<std::string, std::string>, std::vector<Contact> > ContactMap;
+    typedef std::map<std::string, DetailedDistance> DistanceDetailedMap;
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
@@ -147,6 +168,7 @@ namespace collision_detection
     {
       collision = false;
       distance = std::numeric_limits<double>::max();
+      distance_detailed.clear();
       contact_count = 0;
       contacts.clear();
       cost_sources.clear();
@@ -157,6 +179,9 @@ namespace collision_detection
 
     /** \brief Closest distance between two bodies */
     double               distance;
+
+    /** \brief Map of closest distance and points between two bodies */
+    DistanceDetailedMap distance_detailed;
 
     /** \brief Number of contacts returned */
     std::size_t          contact_count;

--- a/collision_detection/include/moveit/collision_detection/collision_common.h
+++ b/collision_detection/include/moveit/collision_detection/collision_common.h
@@ -131,25 +131,6 @@ namespace collision_detection
     }
   };
 
-  /** \brief Representation of a detailed distance */
-  struct DetailedDistance
-  {
-    DetailedDistance(std::string nearest_object, fcl::DistanceResult dist_result)
-    {
-      this->distance = dist_result.min_distance;
-      this->nearest_object = nearest_object;
-      this->nearest_points.first = Eigen::Vector3d(dist_result.nearest_points[0].data.vs);
-      this->nearest_points.second = Eigen::Vector3d(dist_result.nearest_points[1].data.vs);
-    }
-    DetailedDistance(){}
-
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-
-    double distance; /**< Distance between objects */
-    std::string nearest_object; /**< Nearest object link name */
-    std::pair<Eigen::Vector3d, Eigen::Vector3d> nearest_points; /**< Point on each object */
-  };
-
   /** \brief Representation of a collision checking result */
   struct CollisionResult
   {
@@ -159,7 +140,7 @@ namespace collision_detection
     {
     }
     typedef std::map<std::pair<std::string, std::string>, std::vector<Contact> > ContactMap;
-    typedef std::map<std::string, DetailedDistance> DistanceDetailedMap;
+    typedef std::map<std::string, fcl::DistanceResult> DistanceDetailedMap;
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 

--- a/collision_detection/include/moveit/collision_detection/collision_robot.h
+++ b/collision_detection/include/moveit/collision_detection/collision_robot.h
@@ -41,6 +41,7 @@
 #include <moveit/robot_state/robot_state.h>
 #include <moveit_msgs/LinkPadding.h>
 #include <moveit_msgs/LinkScale.h>
+#include <moveit/collision_detection/collision_common.h>
 
 namespace collision_detection
 {
@@ -165,6 +166,14 @@ namespace collision_detection
         the distances between links that are allowed to always collide (as specified by \e acm) */
     virtual double distanceSelf(const robot_state::RobotState &state,
                                 const AllowedCollisionMatrix &acm) const = 0;
+
+    /** \brief The detailed distance to self-collision given the robot is at state \e state. */
+    virtual CollisionResult::DistanceDetailedMap distanceSelfDetailed(const robot_state::RobotState &state) const = 0;
+
+    /** \brief The detailed distance to self-collision given the robot is at state \e state, ignoring
+        the distances between links that are allowed to always collide (as specified by \e acm) */
+    virtual CollisionResult::DistanceDetailedMap distanceSelfDetailed(const robot_state::RobotState &state,
+                                                                  const AllowedCollisionMatrix &acm) const = 0;
 
     /** \brief The distance to another robot instance.
         @param state The state of this robot to consider

--- a/collision_detection/include/moveit/collision_detection/collision_robot.h
+++ b/collision_detection/include/moveit/collision_detection/collision_robot.h
@@ -168,12 +168,12 @@ namespace collision_detection
                                 const AllowedCollisionMatrix &acm) const = 0;
 
     /** \brief The detailed distance to self-collision given the robot is at state \e state. */
-    virtual CollisionResult::DistanceDetailedMap distanceSelfDetailed(const robot_state::RobotState &state) const = 0;
+    virtual CollisionResult::DistanceDetailedMap distanceSelfDetailed(const robot_state::RobotState &state) const;
 
     /** \brief The detailed distance to self-collision given the robot is at state \e state, ignoring
         the distances between links that are allowed to always collide (as specified by \e acm) */
     virtual CollisionResult::DistanceDetailedMap distanceSelfDetailed(const robot_state::RobotState &state,
-                                                                  const AllowedCollisionMatrix &acm) const = 0;
+                                                                  const AllowedCollisionMatrix &acm) const;
 
     /** \brief The distance to another robot instance.
         @param state The state of this robot to consider

--- a/collision_detection/src/collision_robot.cpp
+++ b/collision_detection/src/collision_robot.cpp
@@ -255,11 +255,13 @@ void collision_detection::CollisionRobot::updatedPaddingOrScaling(const std::vec
 {
 }
 
+// The default implementation is being implemented for backward compatibility.
 collision_detection::CollisionResult::DistanceDetailedMap collision_detection::CollisionRobot::distanceSelfDetailed(const robot_state::RobotState &state) const
 {
   throw moveit::Exception("This method has not been implemented. It should be implemented by the inheriting class.");
 }
 
+// The default implementation is being implemented for backward compatibility.
 collision_detection::CollisionResult::DistanceDetailedMap collision_detection::CollisionRobot::distanceSelfDetailed(const robot_state::RobotState &state,
                                                               const collision_detection::AllowedCollisionMatrix &acm) const
 {

--- a/collision_detection/src/collision_robot.cpp
+++ b/collision_detection/src/collision_robot.cpp
@@ -254,3 +254,14 @@ void collision_detection::CollisionRobot::getScale(std::vector<moveit_msgs::Link
 void collision_detection::CollisionRobot::updatedPaddingOrScaling(const std::vector<std::string> &links)
 {
 }
+
+collision_detection::CollisionResult::DistanceDetailedMap collision_detection::CollisionRobot::distanceSelfDetailed(const robot_state::RobotState &state) const
+{
+  throw moveit::Exception("This method has not been implemented. It should be implemented by the inheriting class.");
+}
+
+collision_detection::CollisionResult::DistanceDetailedMap collision_detection::CollisionRobot::distanceSelfDetailed(const robot_state::RobotState &state,
+                                                              const collision_detection::AllowedCollisionMatrix &acm) const
+{
+  throw moveit::Exception("This method has not been implemented. It should be implemented by the inheriting class.");
+}

--- a/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_common.h
+++ b/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_common.h
@@ -213,6 +213,8 @@ bool collisionCallback(fcl::CollisionObject *o1, fcl::CollisionObject *o2, void 
 
 bool distanceCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void *data, double& min_dist);
 
+bool distanceDetailedCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2, void *data, double& min_dist);
+
 FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr &shape,
                                             const robot_model::LinkModel *link,
                                             int shape_index);

--- a/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_robot_fcl.h
+++ b/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_robot_fcl.h
@@ -70,6 +70,8 @@ namespace collision_detection
 
     virtual double distanceSelf(const robot_state::RobotState &state) const;
     virtual double distanceSelf(const robot_state::RobotState &state, const AllowedCollisionMatrix &acm) const;
+    virtual CollisionResult::DistanceDetailedMap distanceSelfDetailed(const robot_state::RobotState &state) const;
+    virtual CollisionResult::DistanceDetailedMap distanceSelfDetailed(const robot_state::RobotState &state, const AllowedCollisionMatrix &acm) const;
     virtual double distanceOther(const robot_state::RobotState &state,
                                  const CollisionRobot &other_robot, const robot_state::RobotState &other_state) const;
     virtual double distanceOther(const robot_state::RobotState &state, const CollisionRobot &other_robot,
@@ -88,6 +90,7 @@ namespace collision_detection
                                    const CollisionRobot &other_robot, const robot_state::RobotState &other_state,
                                    const AllowedCollisionMatrix *acm) const;
     double distanceSelfHelper(const robot_state::RobotState &state, const AllowedCollisionMatrix *acm) const;
+    collision_detection::CollisionResult::DistanceDetailedMap distanceSelfDetailedHelper(const robot_state::RobotState &state, const AllowedCollisionMatrix *acm) const;
     double distanceOtherHelper(const robot_state::RobotState &state, const CollisionRobot &other_robot,
                                const robot_state::RobotState &other_state, const AllowedCollisionMatrix *acm) const;
 

--- a/collision_detection_fcl/src/collision_common.cpp
+++ b/collision_detection_fcl/src/collision_common.cpp
@@ -535,44 +535,35 @@ bool distanceDetailedCallback(fcl::CollisionObject* o1, fcl::CollisionObject* o2
   fcl::DistanceResult dist_result;
   double d = fcl::distance(o1, o2, fcl::DistanceRequest(true), dist_result);
 
-  // Store detailed distance information for each objects
-  collision_detection::DetailedDistance distance_detailed1(cd2->ptr.obj->id_, dist_result);
-  collision_detection::DetailedDistance distance_detailed2;
-  std::map<std::string, collision_detection::DetailedDistance>::iterator it;
-
-  distance_detailed2.distance = distance_detailed1.distance;
-  distance_detailed2.nearest_object = cd1->ptr.obj->id_;
-  distance_detailed2.nearest_points.first = distance_detailed1.nearest_points.second;
-  distance_detailed2.nearest_points.second = distance_detailed1.nearest_points.first;
-
-  // Check if either object is already in the map. If not add it and if present
+  // Check if either object is already in the map. If not add it or if present
   // check to see if the new distance is closer. If closer remove the existing
   // one and add the new distance information.
+  std::map<std::string, fcl::DistanceResult>::iterator it;
   it = cdata->res_->distance_detailed.find(cd1->ptr.obj->id_);
   if (it == cdata->res_->distance_detailed.end())
   {
-    cdata->res_->distance_detailed.insert(std::make_pair<std::string, collision_detection::DetailedDistance>(cd1->ptr.obj->id_, distance_detailed1));
+    cdata->res_->distance_detailed.insert(std::make_pair<std::string, fcl::DistanceResult>(cd1->ptr.obj->id_, dist_result));
   }
   else
   {
-    if (distance_detailed1.distance < it->second.distance)
+    if (dist_result.min_distance < it->second.min_distance)
     {
-        cdata->res_->distance_detailed.erase(cd1->ptr.obj->id_);
-        cdata->res_->distance_detailed.insert(std::make_pair<std::string, collision_detection::DetailedDistance>(cd1->ptr.obj->id_, distance_detailed1));
+      cdata->res_->distance_detailed.erase(cd1->ptr.obj->id_);
+      cdata->res_->distance_detailed.insert(std::make_pair<std::string, fcl::DistanceResult>(cd1->ptr.obj->id_, dist_result));
     }
   }
 
   it = cdata->res_->distance_detailed.find(cd2->ptr.obj->id_);
   if (it == cdata->res_->distance_detailed.end())
   {
-    cdata->res_->distance_detailed.insert(std::make_pair<std::string, collision_detection::DetailedDistance>(cd2->ptr.obj->id_, distance_detailed2));
+    cdata->res_->distance_detailed.insert(std::make_pair<std::string, fcl::DistanceResult>(cd2->ptr.obj->id_, dist_result));
   }
   else
   {
-    if (distance_detailed1.distance < it->second.distance)
+    if (dist_result.min_distance < it->second.min_distance)
     {
-        cdata->res_->distance_detailed.erase(cd2->ptr.obj->id_);
-        cdata->res_->distance_detailed.insert(std::make_pair<std::string, collision_detection::DetailedDistance>(cd2->ptr.obj->id_, distance_detailed2));
+      cdata->res_->distance_detailed.erase(cd2->ptr.obj->id_);
+      cdata->res_->distance_detailed.insert(std::make_pair<std::string, fcl::DistanceResult>(cd2->ptr.obj->id_, dist_result));
     }
   }
 

--- a/collision_detection_fcl/src/collision_robot_fcl.cpp
+++ b/collision_detection_fcl/src/collision_robot_fcl.cpp
@@ -219,6 +219,17 @@ double collision_detection::CollisionRobotFCL::distanceSelf(const robot_state::R
   return distanceSelfHelper(state, &acm);
 }
 
+collision_detection::CollisionResult::DistanceDetailedMap collision_detection::CollisionRobotFCL::distanceSelfDetailed(const robot_state::RobotState &state) const
+{
+  return distanceSelfDetailedHelper(state, NULL);
+}
+
+collision_detection::CollisionResult::DistanceDetailedMap collision_detection::CollisionRobotFCL::distanceSelfDetailed(const robot_state::RobotState &state,
+                                                            const AllowedCollisionMatrix &acm) const
+{
+  return distanceSelfDetailedHelper(state, &acm);
+}
+
 double collision_detection::CollisionRobotFCL::distanceSelfHelper(const robot_state::RobotState &state,
                                                                   const AllowedCollisionMatrix *acm) const
 {
@@ -233,6 +244,23 @@ double collision_detection::CollisionRobotFCL::distanceSelfHelper(const robot_st
   manager.manager_->distance(&cd, &distanceCallback);
 
   return res.distance;
+}
+
+collision_detection::CollisionResult::DistanceDetailedMap collision_detection::CollisionRobotFCL::distanceSelfDetailedHelper(const robot_state::RobotState &state,
+                                                                          const AllowedCollisionMatrix *acm) const
+{
+  FCLManager manager;
+  allocSelfCollisionBroadPhase(state, manager);
+
+  CollisionRequest req;
+  CollisionResult res;
+
+  CollisionData cd(&req, &res, acm);
+  cd.enableGroup(getRobotModel());
+
+  manager.manager_->distance(&cd, &distanceDetailedCallback);
+
+  return res.distance_detailed;
 }
 
 double collision_detection::CollisionRobotFCL::distanceOther(const robot_state::RobotState &state,


### PR DESCRIPTION
This PR is to expose detailed distance information by adding a distanceSelfDetailed(..) function call to collision_detection/collision_robot.h. This function will return a map containing detailed distance information for each object in the robot model.
- Added data structure DetailedDistance to collision_detection/collision_common.h to store distance information for a single collision object.
- Added member distance_detailed to CollisionResult struncture in collision_detection/collision_common.h which is a map of DetailedDistance used to store distance information for each collision objects.
- Added new distance callback function to be passed to fcl called distanceDetailedCallback(..) in collision_detection_fcl/src/collision_common.cpp which populate the distance_detailed member of the CollisionResult structure.
